### PR TITLE
Correct default version of extension to 3.0.0

### DIFF
--- a/count_distinct.control
+++ b/count_distinct.control
@@ -1,4 +1,4 @@
 # count_distinct aggregate
 comment = 'An alternative to COUNT(DISTINCT ...) aggregate, usable with HashAggregate'
-default_version = '2.0.0'
+default_version = '3.0.0'
 relocatable = true


### PR DESCRIPTION
This solves deployment issues into a clean postgresql 9.5 installation where
the extension is not installed
